### PR TITLE
Changed Client construction to treat missing API key as an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - **Breaking:** The tool argument is passed as a string containing JSON.
+- **Breaking:** `openai.NewClient()` and `openai.NewClientWithOptions()` now return `(*Client, error)` instead of `*Client`. An empty API key returns `openai.ErrMissingAPIKey` instead of nil.
 
 ## 0.1.0  - 2025-12-13
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ func main() {
         Level: slog.LevelDebug,
     })))
 
-    client := openai.NewClient("your-api-key")
+    client, err := openai.NewClient("your-api-key")
+    if err != nil {
+        log.Fatal(err)
+    }
 
     // Create chat with system logger
     chat := &goaitools.Chat{
@@ -223,27 +226,15 @@ response, err := chat.Chat(
 ### OpenAI Client Options
 
 ```go
-client := openai.NewClientWithOptions(
+client, err := openai.NewClientWithOptions(
     apiKey,
     openai.WithModel("gpt-4"),
     openai.WithBaseURL("https://custom-endpoint.com"),
     openai.WithSystemLogger(goaitools.NewSlogSystemLogger()),
     openai.WithHTTPClient(customHTTPClient),
 )
-```
-
-### Graceful Degradation
-
-The project that created this package had a graceful degradation pattern should an OpenAI key
-not be defined. That remains in this codebase, however I'd recommend that client code is responsible
-for this behaviour. Ideally I'd plan to remove this feature and have NewClient() return an error
-if the key is missing.
-
-```go
-// Client returns nil if API key is empty
-client := openai.NewClient("")
-if client == nil {
-    // AI features disabled - fall back to alternative behavior
+if err != nil {
+    log.Fatal(err)
 }
 ```
 

--- a/aitooling/tool_test.go
+++ b/aitooling/tool_test.go
@@ -15,9 +15,9 @@ type mockTool struct {
 	executeFunc func(ctx ToolExecuteContext, req *ToolRequest) (*ToolResult, error)
 }
 
-func (m *mockTool) Name() string                 { return m.name }
-func (m *mockTool) Description() string          { return m.description }
-func (m *mockTool) Parameters() json.RawMessage  { return m.parameters }
+func (m *mockTool) Name() string                { return m.name }
+func (m *mockTool) Description() string         { return m.description }
+func (m *mockTool) Parameters() json.RawMessage { return m.parameters }
 func (m *mockTool) Execute(ctx ToolExecuteContext, req *ToolRequest) (*ToolResult, error) {
 	if m.executeFunc != nil {
 		return m.executeFunc(ctx, req)

--- a/example/hellowithtools/game.go
+++ b/example/hellowithtools/game.go
@@ -11,11 +11,11 @@ import (
 // Game represents a simple fake game with various properties.
 // This is a minimal model used to demonstrate tool interactions.
 type Game struct {
-	Title      string    `json:"title"`
-	StartDate  time.Time `json:"start_date"`
-	DurationMinutes int   `json:"duration_minutes"`
-	GridM      int       `json:"grid_m"`
-	GridN      int       `json:"grid_n"`
+	Title           string    `json:"title"`
+	StartDate       time.Time `json:"start_date"`
+	DurationMinutes int       `json:"duration_minutes"`
+	GridM           int       `json:"grid_m"`
+	GridN           int       `json:"grid_n"`
 }
 
 // NewGame creates a new Game with default values

--- a/example/hellowithtools/main.go
+++ b/example/hellowithtools/main.go
@@ -39,9 +39,9 @@ func main() {
 	}
 
 	// Create OpenAI client and chat
-	client := openai.NewClient(apiKey)
-	if client == nil {
-		log.Fatal("Failed to create OpenAI client")
+	client, err := openai.NewClient(apiKey)
+	if err != nil {
+		log.Fatalf("Failed to create OpenAI client: %v", err)
 	}
 
 	chat := &goaitools.Chat{

--- a/openai/client_test.go
+++ b/openai/client_test.go
@@ -12,18 +12,26 @@ import (
 	"github.com/m0rjc/goaitools/aitooling"
 )
 
-// Test: NewClient with empty API key returns nil (graceful degradation)
-func TestNewClient_EmptyAPIKey_ReturnsNil(t *testing.T) {
-	client := NewClient("")
+// Test: NewClient with empty API key returns ErrMissingAPIKey
+func TestNewClient_EmptyAPIKey_ReturnsError(t *testing.T) {
+	client, err := NewClient("")
+
+	if err != ErrMissingAPIKey {
+		t.Errorf("Expected ErrMissingAPIKey, got %v", err)
+	}
 
 	if client != nil {
-		t.Error("NewClient with empty API key should return nil")
+		t.Error("NewClient with empty API key should return nil client")
 	}
 }
 
 // Test: NewClient with valid API key returns configured client
 func TestNewClient_ValidAPIKey_ReturnsClient(t *testing.T) {
-	client := NewClient("sk-test123")
+	client, err := NewClient("sk-test123")
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 
 	if client == nil {
 		t.Fatal("NewClient with valid API key should return client")
@@ -46,18 +54,26 @@ func TestNewClient_ValidAPIKey_ReturnsClient(t *testing.T) {
 	}
 }
 
-// Test: NewClientWithOptions with empty API key returns nil
-func TestNewClientWithOptions_EmptyAPIKey_ReturnsNil(t *testing.T) {
-	client := NewClientWithOptions("", WithModel("gpt-4"))
+// Test: NewClientWithOptions with empty API key returns ErrMissingAPIKey
+func TestNewClientWithOptions_EmptyAPIKey_ReturnsError(t *testing.T) {
+	client, err := NewClientWithOptions("", WithModel("gpt-4"))
+
+	if err != ErrMissingAPIKey {
+		t.Errorf("Expected ErrMissingAPIKey, got %v", err)
+	}
 
 	if client != nil {
-		t.Error("NewClientWithOptions with empty API key should return nil")
+		t.Error("NewClientWithOptions with empty API key should return nil client")
 	}
 }
 
 // Test: WithModel option sets custom model
 func TestClientOptions_WithModel(t *testing.T) {
-	client := NewClientWithOptions("sk-test", WithModel("gpt-4-turbo"))
+	client, err := NewClientWithOptions("sk-test", WithModel("gpt-4-turbo"))
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 
 	if client.model != "gpt-4-turbo" {
 		t.Errorf("Expected model='gpt-4-turbo', got '%s'", client.model)
@@ -67,7 +83,11 @@ func TestClientOptions_WithModel(t *testing.T) {
 // Test: WithBaseURL option sets custom base URL
 func TestClientOptions_WithBaseURL(t *testing.T) {
 	customURL := "https://custom-api.example.com/v1"
-	client := NewClientWithOptions("sk-test", WithBaseURL(customURL))
+	client, err := NewClientWithOptions("sk-test", WithBaseURL(customURL))
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 
 	if client.baseURL != customURL {
 		t.Errorf("Expected baseURL='%s', got '%s'", customURL, client.baseURL)
@@ -80,7 +100,11 @@ func TestClientOptions_WithHTTPClient(t *testing.T) {
 		Timeout: 60 * time.Second,
 	}
 
-	client := NewClientWithOptions("sk-test", WithHTTPClient(customClient))
+	client, err := NewClientWithOptions("sk-test", WithHTTPClient(customClient))
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 
 	if client.httpClient != customClient {
 		t.Error("Expected custom HTTP client to be set")
@@ -95,7 +119,11 @@ func TestClientOptions_WithHTTPClient(t *testing.T) {
 func TestClientOptions_WithSystemLogger(t *testing.T) {
 	logger := goaitools.NewSilentLogger()
 
-	client := NewClientWithOptions("sk-test", WithSystemLogger(logger))
+	client, err := NewClientWithOptions("sk-test", WithSystemLogger(logger))
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 
 	if client.systemLogger != logger {
 		t.Error("Expected custom logger to be set")
@@ -107,13 +135,17 @@ func TestClientOptions_MultipleOptions(t *testing.T) {
 	customHTTP := &http.Client{Timeout: 45 * time.Second}
 	logger := goaitools.NewSilentLogger()
 
-	client := NewClientWithOptions(
+	client, err := NewClientWithOptions(
 		"sk-test",
 		WithModel("gpt-4"),
 		WithBaseURL("https://custom.example.com"),
 		WithHTTPClient(customHTTP),
 		WithSystemLogger(logger),
 	)
+
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
 
 	if client.model != "gpt-4" {
 		t.Error("Model option not applied")
@@ -309,10 +341,14 @@ func TestClient_ChatCompletion_Integration(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClientWithOptions(
+	client, err := NewClientWithOptions(
 		"sk-test",
 		WithBaseURL(server.URL),
 	)
+
+	if err != nil {
+		t.Fatalf("Expected no error creating client, got %v", err)
+	}
 
 	result, err := client.ChatCompletion(
 		context.Background(),


### PR DESCRIPTION
This removes a pattern that the code inherited from its parent project.

This module should not be responsible for deciding whether you have an API key set up.